### PR TITLE
Fix a bug of inline math equation

### DIFF
--- a/.changeset/great-cats-try.md
+++ b/.changeset/great-cats-try.md
@@ -1,0 +1,9 @@
+---
+"@dolphin/lark": patch
+---
+
+fix: The text content does not necessarily have an ENTER at the end (#3)
+
+Contributors:
+- @lujunji4113
+- @starsflow

--- a/packages/lark/src/docx.ts
+++ b/packages/lark/src/docx.ts
@@ -528,7 +528,7 @@ export const transformOperationsToPhrasingContents = (
     if (equation && equation.length > 1) {
       return {
         type: 'inlineMath',
-        value: equation.slice(0, -1),
+        value: equation.slice(0),
       }
     }
 

--- a/packages/lark/src/docx.ts
+++ b/packages/lark/src/docx.ts
@@ -288,6 +288,14 @@ type Blocks =
   | Whiteboard
   | NotSupportedBlock
 
+/**
+ * @description Removes an enter from the end of this string if it exists.
+ */
+const trimEndEnter = (input: string) =>
+  input.length > 0 && input[input.length - 1] === '\n'
+    ? input.slice(0, -1)
+    : input
+
 const chunkBy = <T>(
   items: T[],
   isEqual: (current: T, next: T) => boolean,
@@ -528,7 +536,7 @@ export const transformOperationsToPhrasingContents = (
     if (equation && equation.length > 1) {
       return {
         type: 'inlineMath',
-        value: equation.slice(0),
+        value: trimEndEnter(equation),
       }
     }
 
@@ -596,7 +604,7 @@ const whiteboardToImageData = async (
 }
 
 const evaluateAlt = (caption?: Caption) =>
-  (caption?.text.initialAttributedTexts.text?.[0] ?? '').slice(0, -1)
+  trimEndEnter(caption?.text.initialAttributedTexts.text?.[0] ?? '')
 
 type Mutate<T extends Block> = T extends PageBlock
   ? mdast.Root
@@ -733,7 +741,7 @@ export class Transformer {
         const code: mdast.Code = {
           type: 'code',
           lang: block.language.toLocaleLowerCase(),
-          value: block.zoneState?.allText.slice(0, -1) ?? '',
+          value: trimEndEnter(block.zoneState?.allText ?? ''),
         }
         return code
       }
@@ -915,7 +923,7 @@ export class Docx {
   get pageTitle() {
     if (!this.rootBlock || !this.rootBlock.zoneState) return null
 
-    return this.rootBlock.zoneState.allText.slice(0, -1)
+    return trimEndEnter(this.rootBlock.zoneState.allText)
   }
 
   isReady() {

--- a/packages/lark/tests/docx.test.ts
+++ b/packages/lark/tests/docx.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, expect } from 'vitest'
+import { test, describe, expect, it } from 'vitest'
 import * as mdast from 'mdast'
 import {
   BlockType,
@@ -1228,6 +1228,102 @@ describe('transformer.transform()', () => {
         ],
       }
       expect(root).toStrictEqual(expectedRoot)
+    })
+  })
+})
+
+describe('trim end enter', () => {
+  describe('inline math', () => {
+    it('with enter', () => {
+      expect(
+        transformer.transform({
+          type: BlockType.PAGE,
+          snapshot: {
+            type: BlockType.PAGE,
+          },
+          children: [
+            {
+              type: BlockType.TEXT,
+              snapshot: {
+                type: BlockType.TEXT,
+              },
+              zoneState: {
+                allText: '',
+                content: {
+                  ops: [
+                    {
+                      insert: '',
+                      attributes: {
+                        equation: 'math\n',
+                      },
+                    },
+                  ],
+                },
+              },
+              children: [],
+            },
+          ],
+        }).root,
+      ).toStrictEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'inlineMath',
+                value: 'math',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('without enter', () => {
+      expect(
+        transformer.transform({
+          type: BlockType.PAGE,
+          snapshot: {
+            type: BlockType.PAGE,
+          },
+          children: [
+            {
+              type: BlockType.TEXT,
+              snapshot: {
+                type: BlockType.TEXT,
+              },
+              zoneState: {
+                allText: '',
+                content: {
+                  ops: [
+                    {
+                      insert: '',
+                      attributes: {
+                        equation: 'math',
+                      },
+                    },
+                  ],
+                },
+              },
+              children: [],
+            },
+          ],
+        }).root,
+      ).toStrictEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'inlineMath',
+                value: 'math',
+              },
+            ],
+          },
+        ],
+      })
     })
   })
 })


### PR DESCRIPTION
Fix the bug of converting inline math equation with the last latex character missed. I think it's because the result obtained by `slice()` does not include the right boundary, which is the last character in the implementation of `Line 531`.

https://github.com/lujunji4113/cloud-document-converter/blob/9d8f76b7ef490eb083108f51f45c7510cae27053/packages/lark/src/docx.ts#L528-L533