### PR TITLE
fix: inline equation

### DIFF
--- a/.changeset/four-eggs-tan.md
+++ b/.changeset/four-eggs-tan.md
@@ -1,0 +1,5 @@
+---
+"@dolphin/lark": patch
+---
+
+fix: inline equation with a single character will lost after converted

--- a/packages/lark/src/docx.ts
+++ b/packages/lark/src/docx.ts
@@ -533,7 +533,7 @@ export const transformOperationsToPhrasingContents = (
       }
     }
 
-    if (equation && equation.length > 1) {
+    if (equation && equation.length > 0) {
       return {
         type: 'inlineMath',
         value: trimEndEnter(equation),

--- a/packages/lark/tests/docx.test.ts
+++ b/packages/lark/tests/docx.test.ts
@@ -1327,3 +1327,51 @@ describe('trim end enter', () => {
     })
   })
 })
+
+describe('inline math', () => {
+  test('inline equation with a single character', () => {
+    expect(
+      transformer.transform({
+        type: BlockType.PAGE,
+        snapshot: {
+          type: BlockType.PAGE,
+        },
+        children: [
+          {
+            type: BlockType.TEXT,
+            snapshot: {
+              type: BlockType.TEXT,
+            },
+            zoneState: {
+              allText: '',
+              content: {
+                ops: [
+                  {
+                    insert: '',
+                    attributes: {
+                      equation: 'a',
+                    },
+                  },
+                ],
+              },
+            },
+            children: [],
+          },
+        ],
+      }).root,
+    ).toStrictEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'inlineMath',
+              value: 'a',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
inline equation with a single character will lost after converted, please see https://github.com/lujunji4113/cloud-document-converter/pull/3#issuecomment-2308744209